### PR TITLE
Trenton sol compiles

### DIFF
--- a/trentonHW4/Trenton_HW5sol.hs
+++ b/trentonHW4/Trenton_HW5sol.hs
@@ -28,7 +28,18 @@ semCmd (LDI (I i)) s = A ((I i):s)
 semCmd (LDB (B b)) s = A ((B b):s)
 
 semCmd DUP [] = RankError
-semCmd DUP ( (x:xs)) = A (x:x:xs)
+semCmd DUP (x:xs) = A (x:x:xs)
+
+semCmd DEC [] = RankError
+semCmd DEC ((I x):xs) = A ((x-1):xs)
+
+semCmd (POP _) [] = RankError
+semCmd (POP 1) (x:xs) = A xs
+semCmd (POP k) (x:xs) = semCmd (POP (k-1)) xs
+
+semCmd SWAP [] = RankError
+semCmd SWAP (x:y:xs) = A (y:x:xs)
+semCmd SWAP _ = RankError
 
 semCmd ADD [] = RankError
 semCmd ADD ((I x):[]) = RankError

--- a/trentonHW4/Trenton_HW5sol.hs
+++ b/trentonHW4/Trenton_HW5sol.hs
@@ -24,29 +24,29 @@ type CmdRank = (Int, Int)
 
 semCmd :: Cmd -> Stack -> Result
 
-semCmd (LDI (I i)) (A s) = A ((I i):s)
-semCmd (LDB (B b)) (A s) = A ((B b):s)
+semCmd (LDI (I i)) s = A ((I i):s)
+semCmd (LDB (B b)) s = A ((B b):s)
 
-semCmd DUP (A []) = RankError
-semCmd DUP (A (x:xs)) = A (x:x:xs)
+semCmd DUP [] = RankError
+semCmd DUP ( (x:xs)) = A (x:x:xs)
 
-semCmd ADD (A []) = RankError
-semCmd ADD (A ((I x):[])) = RankError
-semCmd ADD (A ((I x):(I y):s)) = A ((I (x+y)):s)
+semCmd ADD [] = RankError
+semCmd ADD ((I x):[]) = RankError
+semCmd ADD ((I x):(I y):s) = A ((I (x+y)):s)
 semCmd ADD _ = TypeError
 
-semCmd MULT (A []) = RankError
-semCmd MULT (A ((I x):[])) = RankError
-semCmd MULT (A ((I x):(I y):s)) = A ((I(x*y)):s)
+semCmd MULT [] = RankError
+semCmd MULT ((I x):[]) = RankError
+semCmd MULT ((I x):(I y):s) = A ((I(x*y)):s)
 semCmd MULT _ = RankError
 
-semCmd LEQ (A []) = RankError
-semCmd LEQ (A ((I x):[])) = RankError
-semCmd LEQ (A ((I x):(I y):s)) = A ((B (x<=y)):s)
+semCmd LEQ [] = RankError
+semCmd LEQ ((I x):[]) = RankError
+semCmd LEQ ((I x):(I y):s) = A ((B (x<=y)):s)
 semCmd LEQ _ = RankError
 
-semCmd (IFELSE t f) (A []) = RankError
-semCmd (IFELSE t f) (A ((B x):xs)) = run (if x then t else f) xs
+semCmd (IFELSE t f) [] = RankError
+semCmd (IFELSE t f) ((B x):xs) = run (if x then t else f) xs
 semCmd (IFELSE t f) _ = RankError
 
 run :: Prog -> Stack -> Result

--- a/trentonHW4/Trenton_HW5sol.hs
+++ b/trentonHW4/Trenton_HW5sol.hs
@@ -28,7 +28,18 @@ semCmd (LDI (I i)) s = A ((I i):s)
 semCmd (LDB (B b)) s = A ((B b):s)
 
 semCmd DUP [] = RankError
-semCmd DUP ( (x:xs)) = A (x:x:xs)
+semCmd DUP (x:xs) = A (x:x:xs)
+
+semCmd DEC [] = RankError
+semCmd DEC ((I x):xs) = A ((x-1):xs)
+
+semCmd (POP _) [] = RankError
+semCmd (POP 1) (x:xs) = A xs
+semCmd (POP k) (x:xs) = semCmd POP (k-1) xs
+
+semCmd SWAP [] = RankError
+semCmd SWAP (x:y:xs) = A (y:x:xs)
+semCmd SWAP _ = RankError
 
 semCmd ADD [] = RankError
 semCmd ADD ((I x):[]) = RankError

--- a/trentonHW4/Trenton_HW5sol.hs
+++ b/trentonHW4/Trenton_HW5sol.hs
@@ -24,29 +24,29 @@ type CmdRank = (Int, Int)
 
 semCmd :: Cmd -> Stack -> Result
 
-semCmd (LDI (I i)) s = (A i):s
-semCmd (LDB (B b)) s = (A b):s
+semCmd (LDI (I i)) (A s) = A ((I i):s)
+semCmd (LDB (B b)) (A s) = A ((B b):s)
 
-semCmd DUP [] = RankError
-semCmd DUP (x:xs) = A (x:x:xs)
+semCmd DUP (A []) = RankError
+semCmd DUP (A (x:xs)) = A (x:x:xs)
 
-semCmd ADD [] = RankError
-semCmd ADD ((I x):[]) = RankError
-semCmd ADD ((I x):(I y):s) = A ((I (x+y)):s)
+semCmd ADD (A []) = RankError
+semCmd ADD (A ((I x):[])) = RankError
+semCmd ADD (A ((I x):(I y):s)) = A ((I (x+y)):s)
 semCmd ADD _ = TypeError
 
-semCmd MULT [] = RankError
-semCmd MULT ((I x):[]) = RankError
-semCmd MULT ((I x):(I y):s) = A ((I(x*y)):s)
+semCmd MULT (A []) = RankError
+semCmd MULT (A ((I x):[])) = RankError
+semCmd MULT (A ((I x):(I y):s)) = A ((I(x*y)):s)
 semCmd MULT _ = RankError
 
-semCmd LEQ [] = RankError
-semCmd LEQ ((I x):[]) = RankError
-semCmd LEQ ((I x):(I y):s) = A ((B (x<=y)):s)
+semCmd LEQ (A []) = RankError
+semCmd LEQ (A ((I x):[])) = RankError
+semCmd LEQ (A ((I x):(I y):s)) = A ((B (x<=y)):s)
 semCmd LEQ _ = RankError
 
-semCmd (IFELSE t f) [] = RankError
-semCmd (IFELSE t f) ((B x):xs) = run (if x then t else f) xs
+semCmd (IFELSE t f) (A []) = RankError
+semCmd (IFELSE t f) (A ((B x):xs)) = run (if x then t else f) xs
 semCmd (IFELSE t f) _ = RankError
 
 run :: Prog -> Stack -> Result

--- a/trentonHW4/Trenton_HW5sol.hs
+++ b/trentonHW4/Trenton_HW5sol.hs
@@ -5,9 +5,9 @@ module HW5sol where
 
 -- HW5types.hs
 type Prog = [Cmd]
-data Cmd = LDI Val | ADD | MULT | DUP | DEC
-		| SWAP | POP Val | IFELSE Prog Prog
-		| LDB Val | LEQ
+data Cmd = LDI Int | ADD | MULT | DUP | DEC
+		| SWAP | POP Int | IFELSE Prog Prog
+		| LDB Bool | LEQ
          deriving Show
 
 data Val = I Int | B Bool

--- a/trentonHW4/Trenton_HW5sol.hs
+++ b/trentonHW4/Trenton_HW5sol.hs
@@ -5,9 +5,9 @@ module HW5sol where
 
 -- HW5types.hs
 type Prog = [Cmd]
-data Cmd = LDI Int | ADD | MULT | DUP | DEC
-		| SWAP | POP Int | IFELSE Prog Prog
-		| LDB Bool | LEQ
+data Cmd = LDI Val | ADD | MULT | DUP | DEC
+		| SWAP | POP Val | IFELSE Prog Prog
+		| LDB Val | LEQ
          deriving Show
 
 data Val = I Int | B Bool

--- a/trentonHW4/Trenton_HW5sol.hs
+++ b/trentonHW4/Trenton_HW5sol.hs
@@ -24,8 +24,8 @@ type CmdRank = (Int, Int)
 
 semCmd :: Cmd -> Stack -> Result
 
-semCmd (LDI (I i)) s = A ((I i):s)
-semCmd (LDB (B b)) s = A ((B b):s)
+semCmd (LDI i) s = A ((I i):s)
+semCmd (LDB b) s = A ((B b):s)
 
 semCmd DUP [] = RankError
 semCmd DUP (x:xs) = A (x:x:xs)

--- a/trentonHW4/Trenton_HW5sol.hs
+++ b/trentonHW4/Trenton_HW5sol.hs
@@ -31,7 +31,7 @@ semCmd DUP [] = RankError
 semCmd DUP (x:xs) = A (x:x:xs)
 
 semCmd DEC [] = RankError
-semCmd DEC ((I x):xs) = A ((x-1):xs)
+semCmd DEC ((I x):xs) = A (((I x)-1):xs)
 
 semCmd (POP _) [] = RankError
 semCmd (POP 1) (x:xs) = A xs

--- a/trentonHW4/Trenton_HW5sol.hs
+++ b/trentonHW4/Trenton_HW5sol.hs
@@ -24,8 +24,8 @@ type CmdRank = (Int, Int)
 
 semCmd :: Cmd -> Stack -> Result
 
-semCmd (LDI (I i)) s = A i:s
-semCmd (LDB (B b)) s = A b:s
+semCmd (LDI (I i)) s = (A i):s
+semCmd (LDB (B b)) s = (A b):s
 
 semCmd DUP [] = RankError
 semCmd DUP (x:xs) = A (x:x:xs)

--- a/trentonHW4/Trenton_HW5sol.hs
+++ b/trentonHW4/Trenton_HW5sol.hs
@@ -50,13 +50,9 @@ semCmd (IFELSE t f) ((B x):xs) = run (if x then t else f) xs
 semCmd (IFELSE t f) _ = RankError
 
 run :: Prog -> Stack -> Result
-run []            x       = A x                                -- Once we have run out of cmds, return the remaining stack
---run ((LDI a):xs)  x       = run xs ((I a):x)                  -- For LD integer, append the value to the stack                        -- !!Why aren't these in semCmd?
---run ((LDB a):xs)  x       = run xs ((B a):x)                                                                                          -- !!Why aren't these in semCmd?
---run ((DUP):xs)    x       = if (null x)   then RankError                            -- If the stack has fewer than one element, err   -- !!Why aren't these in semCmd?
---                                          else run xs ((head x):x)                -- Append the head of the stack to it               -- !!Why aren't these in semCmd?
+run [] x     = A x                        -- Once we have run out of cmds, return the remaining stack
 run (c:cs) s = case semCmd c s of
-                  RankError -> RankError      -- If calling secCmd c s results in a RankError, we return a RankError
-                  A s' -> run cs s'           -- If calling secCmd c s results in A (Result Stack) then recursively call run with the remaining cmd's on the Result Stack
-run _             []      = RankError                               -- An empty stack after all that? Errrrrrr
+                  RankError -> RankError  -- If calling secCmd c s results in a RankError, we return a RankError
+                  A s' -> run cs s'       -- If calling secCmd c s results in A (Result Stack) then recursively call run with the remaining cmd's on the Result Stack
+run _ []     = RankError                  -- An empty stack after all that? Errrrrrr
 

--- a/trentonHW4/Trenton_HW5sol.hs
+++ b/trentonHW4/Trenton_HW5sol.hs
@@ -1,0 +1,62 @@
+--Trenton Young
+--youngtre@oregonstate.edu
+
+module HW5sol where
+
+-- HW5types.hs
+type Prog = [Cmd]
+data Cmd = LDI Int | ADD | MULT | DUP | DEC
+		| SWAP | POP Int | IFELSE Prog Prog
+		| LDB Bool | LEQ
+         deriving Show
+
+data Val = I Int | B Bool
+		deriving Show
+
+type Stack = [Val]
+data Result = A Stack | RankError | TypeError
+          deriving Show
+
+type D = Stack -> Stack
+type Rank = Int
+type CmdRank = (Int, Int)
+-- /HW5types.hs
+
+semCmd :: Cmd -> Stack -> Result
+
+semCmd (LDI (I i)) s = A i:s
+semCmd (LDB (B b)) s = A b:s
+
+semCmd DUP [] = RankError
+semCmd DUP (x:xs) = A (x:x:xs)
+
+semCmd ADD [] = RankError
+semCmd ADD ((I x):[]) = RankError
+semCmd ADD ((I x):(I y):s) = A ((I (x+y)):s)
+semCmd ADD _ = TypeError
+
+semCmd MULT [] = RankError
+semCmd MULT ((I x):[]) = RankError
+semCmd MULT ((I x):(I y):s) = A ((I(x*y)):s)
+semCmd MULT _ = RankError
+
+semCmd LEQ [] = RankError
+semCmd LEQ ((I x):[]) = RankError
+semCmd LEQ ((I x):(I y):s) = A ((B (x<=y)):s)
+semCmd LEQ _ = RankError
+
+semCmd (IFELSE t f) [] = RankError
+semCmd (IFELSE t f) ((B x):xs) = run (if x then t else f) xs
+semCmd (IFELSE t f) _ = RankError
+
+run :: Prog -> Stack -> Result
+run []            x       = A x                                -- Once we have run out of cmds, return the remaining stack
+--run ((LDI a):xs)  x       = run xs ((I a):x)                  -- For LD integer, append the value to the stack                        -- !!Why aren't these in semCmd?
+--run ((LDB a):xs)  x       = run xs ((B a):x)                                                                                          -- !!Why aren't these in semCmd?
+--run ((DUP):xs)    x       = if (null x)   then RankError                            -- If the stack has fewer than one element, err   -- !!Why aren't these in semCmd?
+--                                          else run xs ((head x):x)                -- Append the head of the stack to it               -- !!Why aren't these in semCmd?
+run (c:cs) s = case semCmd c s of
+                  RankError -> RankError      -- If calling secCmd c s results in a RankError, we return a RankError
+                  A s' -> run cs s'           -- If calling secCmd c s results in A (Result Stack) then recursively call run with the remaining cmd's on the Result Stack
+run _             []      = RankError                               -- An empty stack after all that? Errrrrrr
+

--- a/trentonHW4/Trenton_HW5sol.hs
+++ b/trentonHW4/Trenton_HW5sol.hs
@@ -31,7 +31,7 @@ semCmd DUP [] = RankError
 semCmd DUP (x:xs) = A (x:x:xs)
 
 semCmd DEC [] = RankError
-semCmd DEC ((I x):xs) = A (((I x)-1):xs)
+semCmd DEC ((I x):xs) = A ((I (x-1)):xs)
 
 semCmd (POP _) [] = RankError
 semCmd (POP 1) (x:xs) = A xs


### PR DESCRIPTION
This PR contains a version of `/trentonHW4/Trenton_HW5sol.hs` that compiles and is basically just a version of HW4 that has the types and new `Cmd`s from HW5 and `TypeError` handling

No changes were made to `/HW5sol.hs` so this can be merged whenever, mostly just a named version for myself