### PR TITLE
New Cmds (Nightly)

### DIFF
--- a/trentonHW4/HW5sol.hs
+++ b/trentonHW4/HW5sol.hs
@@ -2,6 +2,7 @@
 --youngtre@oregonstate.edu
 
 module HW5sol where
+import HW5types
 
 -- HW5types.hs
 --type Prog = [Cmd]

--- a/trentonHW4/HW5sol.hs
+++ b/trentonHW4/HW5sol.hs
@@ -4,22 +4,22 @@
 module HW5sol where
 
 -- HW5types.hs
---type Prog = [Cmd]
---data Cmd = LDI Int | ADD | MULT | DUP | DEC
---		| SWAP | POP Int | IFELSE Prog Prog
---		| LDB Bool | LEQ
---         deriving Show
---
---data Val = I Int | B Bool
---		deriving Show
---
---type Stack = [Val]
---data Result = A Stack | RankError | TypeError
---          deriving Show
---
---type D = Stack -> Stack
---type Rank = Int
---type CmdRank = (Int, Int)
+type Prog = [Cmd]
+data Cmd = LDI Int | ADD | MULT | DUP | DEC
+		| SWAP | POP Int | IFELSE Prog Prog
+		| LDB Bool | LEQ
+         deriving Show
+
+data Val = I Int | B Bool
+		deriving Show
+
+type Stack = [Val]
+data Result = A Stack | RankError | TypeError
+          deriving Show
+
+type D = Stack -> Stack
+type Rank = Int
+type CmdRank = (Int, Int)
 -- /HW5types.hs
 
 semCmd :: Cmd -> Stack -> Result

--- a/trentonHW4/HW5sol.hs
+++ b/trentonHW4/HW5sol.hs
@@ -4,22 +4,22 @@
 module HW5sol where
 
 -- HW5types.hs
-type Prog = [Cmd]
-data Cmd = LDI Int | ADD | MULT | DUP | DEC
-		| SWAP | POP Int | IFELSE Prog Prog
-		| LDB Bool | LEQ
-         deriving Show
-
-data Val = I Int | B Bool
-		deriving Show
-
-type Stack = [Val]
-data Result = A Stack | RankError | TypeError
-          deriving Show
-
-type D = Stack -> Stack
-type Rank = Int
-type CmdRank = (Int, Int)
+--type Prog = [Cmd]
+--data Cmd = LDI Int | ADD | MULT | DUP | DEC
+--		| SWAP | POP Int | IFELSE Prog Prog
+--		| LDB Bool | LEQ
+--         deriving Show
+--
+--data Val = I Int | B Bool
+--		deriving Show
+--
+--type Stack = [Val]
+--data Result = A Stack | RankError | TypeError
+--          deriving Show
+--
+--type D = Stack -> Stack
+--type Rank = Int
+--type CmdRank = (Int, Int)
 -- /HW5types.hs
 
 semCmd :: Cmd -> Stack -> Result

--- a/trentonHW4/HW5types.hs
+++ b/trentonHW4/HW5types.hs
@@ -1,0 +1,20 @@
+-- Homework 5 (types)
+module HW5types where
+import Data.Maybe
+
+type Prog = [Cmd]
+data Cmd = LDI Int | ADD | MULT | DUP | DEC 
+		| SWAP | POP Int | IFELSE Prog Prog
+		| LDB Bool | LEQ
+         deriving Show
+		 
+data Val = I Int | B Bool 
+		deriving Show
+
+type Stack = [Val]
+data Result = A Stack | RankError | TypeError
+          deriving Show
+		  
+type D = Stack -> Stack
+type Rank = Int
+type CmdRank = (Int, Int)

--- a/trentonHW4/hw5verifier.hs
+++ b/trentonHW4/hw5verifier.hs
@@ -1,0 +1,74 @@
+import HW5sol
+import HW5types
+
+-- rankAll ( ranks all programs in pList and stacks sList)
+-- rankAllEmpty (ranks all programs in pList with an empty stack)
+-- runAllTests  ( run all programs in pList with stacks in sList) )
+-- runAllEmpty  ( run all programs in pList with empty stack )
+
+--test programs
+p1 = [LDI 3, DUP, ADD, LDI 5, SWAP] 
+p2 = [LDI 8, POP 1, LDI 3, DUP, POP 2, LDI 4] 
+p3 = [LDI 3, LDI 4, LDI 5, MULT, ADD] 
+p4 = [DUP] 
+p5 = [POP 4] 
+p6 = [LDB True, IFELSE [ADD] [LDI 7], ADD ]
+p7 = [LDB True, LDI 1, LDI 10, LDI 5, IFELSE [ADD] [LDI 7], ADD ]
+p8 = [LDI 20, LDI 1, LDI 10, LDI 5, LEQ, IFELSE [ADD] [LDI 7], DUP ]
+p9 = [LDB True, LDB False, MULT]
+p10 = [LDI 10, DEC, DUP, DUP, DUP, POP 2]
+p11 = [LDI 10, LDI 20, LEQ, DEC]
+p12 = [LDI 10, LDI 5, LDB True, IFELSE [LDB True, IFELSE [ADD, DUP] [MULT]] [LDI 7] ]
+p13 = [LDI 10, LDI 5, LDB True, IFELSE [LDB False, IFELSE [ADD, DUP] [MULT]] [LDI 7] ]
+p14 = [LDI 10, LDI 5, LDB False, IFELSE [LDB True, IFELSE [ADD, DUP] [MULT]] [LDI 7] ]
+p15 = [LDI 10, LDI 5, LDB False, IFELSE [LDB True, IFELSE [ADD, ADD] [MULT]] [LDI 7] ]
+
+pList  = [p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15]
+
+sList =[s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15 ]
+eList = [ [], [],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]]
+s1 = [B True]
+s2 = [I 2]
+s3 = [I 1, I 3]
+s4 = [B False, I 4, I 7]
+s5 = [I 1, I 4, I 6]
+s6 = [I 10]
+s7 = [I 100, I 6]
+s8 = [I 10, I 20, I 1]
+s9 = [I 3, I 8]
+s10 = [I 1, I 4, I 6]
+s11 = [I 10]
+s12 = [I 100, I 6]
+s13 = [I 10, I 20, I 1]
+s14 = [I 3, I 8]
+s15 = [I 3, I 8]
+
+prettyERank :: [Prog] -> [Stack] -> String
+prettyERank [] _ = " "
+prettyERank (p:pp) (s:ss) = "p:"++show(p)++"  s:"++show(s)++" ==> "++show (rankP p (length s))++"\n\n"++ (prettyERank pp ss)
+
+rankAll :: IO ()
+rankAll = putStrLn ("\nRank programs with stacks \n\n"++(prettyERank pList sList))
+
+rankAllEmpty :: IO ()
+rankAllEmpty = putStrLn ("\nRank programs with empty stacks \n\n"++(prettyERank pList eList))
+
+prettySRun :: Prog -> Stack ->String
+prettySRun p s = " s:"++show s++" p:"++show p++" ==> "++show (run p s)++"\n"
+
+
+prettyERun :: Prog -> String
+prettyERun p = show p++" ==> "++show (run p [])++"\n"
+
+
+runS :: [Prog] -> [Stack]-> IO ()
+runS [] _ = putStrLn " "
+runS _ [] = putStrLn " "
+runS (p:ps)(s:ss) = do 
+						putStrLn (prettySRun p s)
+						runS ps ss
+runAll:: IO()
+runAll = runS pList sList
+
+runAllEmpty :: IO()
+runAllEmpty = runS pList eList

--- a/trentonHW4/hw5verifier.hs
+++ b/trentonHW4/hw5verifier.hs
@@ -1,6 +1,5 @@
-
-import HW5types
 import HW5sol
+import HW5types
 
 -- rankAll ( ranks all programs in pList and stacks sList)
 -- rankAllEmpty (ranks all programs in pList with an empty stack)

--- a/trentonHW4/hw5verifier.hs
+++ b/trentonHW4/hw5verifier.hs
@@ -45,7 +45,7 @@ s15 = [I 3, I 8]
 
 prettyERank :: [Prog] -> [Stack] -> String
 prettyERank [] _ = " "
-prettyERank (p:pp) (s:ss) = "p:"++show(p)++"  s:"++show(s)++" ==> "++show (rankP p (length s))++"\n\n"++ (prettyERank pp ss)
+--prettyERank (p:pp) (s:ss) = "p:"++show(p)++"  s:"++show(s)++" ==> "++show (rankP p (length s))++"\n\n"++ (prettyERank pp ss)
 
 rankAll :: IO ()
 rankAll = putStrLn ("\nRank programs with stacks \n\n"++(prettyERank pList sList))

--- a/trentonHW4/hw5verifier.hs
+++ b/trentonHW4/hw5verifier.hs
@@ -1,5 +1,6 @@
-import HW5sol
+
 import HW5types
+import HW5sol
 
 -- rankAll ( ranks all programs in pList and stacks sList)
 -- rankAllEmpty (ranks all programs in pList with an empty stack)


### PR DESCRIPTION
This test yields a RankError when it should be a TypeError
` s:[I 100,I 6] p:[LDB True,LDI 1,LDI 10,LDI 5,IFELSE [ADD] [LDI 7],ADD] ==> RankError`
This one should also be a TypeError
` s:[I 3,I 8] p:[LDB True,LDB False,MULT] ==> RankError`
And this one kicks a non-exhaustive pattern exception 
` s:[I 10] p:[LDI 10,LDI 20,LEQ,DEC]`